### PR TITLE
Compression now active for rotated logs

### DIFF
--- a/ansible/roles/_common/tasks/logrotate.yml
+++ b/ansible/roles/_common/tasks/logrotate.yml
@@ -1,0 +1,15 @@
+---
+
+- name: YUM | Ensure logrotate is here
+  yum:
+    name: logrotate
+    state: present
+
+- name: LINEINFILE | Compression on archiving is enabled
+  lineinfile:
+    path: /etc/logrotate.conf
+    regexp: '^#+\s*(compress).*$'
+    replace: '\1'
+    backrefs: yes
+    
+

--- a/ansible/roles/_common/tasks/main.yml
+++ b/ansible/roles/_common/tasks/main.yml
@@ -110,6 +110,12 @@
     - _common
     - _common_node_exporter
 
+- name: "IMPORT_TASKS | logrotate.yml"
+  import_tasks: logrotate.yml
+  tags:
+    - _common
+    - _common_logrotate
+
 - name: "IMPORT_TASKS | swap.yml"
   import_tasks: swap.yml
   tags:
@@ -121,3 +127,4 @@
   tags:
     - _common
     - _common_system_upgrade
+


### PR DESCRIPTION
By default logrotate does not compress old stuff. This may lead to full /var filesystems. This PR changes turns the compression on for rotated logs.
