### PR TITLE
_common: invalid Ansible parameter fixed for compression in logrotate…

### DIFF
--- a/ansible/roles/_common/tasks/logrotate.yml
+++ b/ansible/roles/_common/tasks/logrotate.yml
@@ -9,7 +9,9 @@
   lineinfile:
     path: /etc/logrotate.conf
     regexp: '^#+\s*(compress).*$'
-    replace: '\1'
+    line: '\1'
     backrefs: yes
-    
+    state: present
+
+
 


### PR DESCRIPTION
an invalid keyword for 'lineinfile' was used. Issue fixed.
