### PR TITLE
Addes6 gitbranch selection

### DIFF
--- a/ansible/group_vars/101
+++ b/ansible/group_vars/101
@@ -16,5 +16,5 @@ ul_aidbox_db_image_tag: "13.2"
 
 # Overrides of Ansible code branches/tags to be used:
 _common_ansible_pull_repo_branch:
-  orange: addes6-gitbranch-selection
+  orange: addes6-podman-pull-avoidance
   green: master

--- a/ansible/group_vars/101
+++ b/ansible/group_vars/101
@@ -13,3 +13,8 @@ ul_aidbox_fhir_version: 4.0.0
 ul_aidbox_db_image_registry: docker.io
 ul_aidbox_db_image_name: healthsamurai/aidboxdb
 ul_aidbox_db_image_tag: "13.2"
+
+# Overrides of Ansible code branches/tags to be used:
+_common_ansible_pull_repo_branch:
+  - orange: master
+  - green: master

--- a/ansible/group_vars/101
+++ b/ansible/group_vars/101
@@ -18,4 +18,3 @@ ul_aidbox_db_image_tag: "13.2"
 _common_ansible_pull_repo_branch:
   orange: addes6-podman-pull-avoidance
   green: addes6-podman-pull-avoidance
-

--- a/ansible/group_vars/101
+++ b/ansible/group_vars/101
@@ -17,4 +17,5 @@ ul_aidbox_db_image_tag: "13.2"
 # Overrides of Ansible code branches/tags to be used:
 _common_ansible_pull_repo_branch:
   orange: addes6-podman-pull-avoidance
-  green: master
+  green: addes6-podman-pull-avoidance
+

--- a/ansible/group_vars/101
+++ b/ansible/group_vars/101
@@ -16,5 +16,5 @@ ul_aidbox_db_image_tag: "13.2"
 
 # Overrides of Ansible code branches/tags to be used:
 _common_ansible_pull_repo_branch:
-  - orange: master
+  - orange: addes6-gitbranch-selection
   - green: master

--- a/ansible/group_vars/101
+++ b/ansible/group_vars/101
@@ -16,5 +16,5 @@ ul_aidbox_db_image_tag: "13.2"
 
 # Overrides of Ansible code branches/tags to be used:
 _common_ansible_pull_repo_branch:
-  - orange: addes6-gitbranch-selection
-  - green: master
+  orange: addes6-gitbranch-selection
+  green: master

--- a/ansible/roles/_common/defaults/main.yml
+++ b/ansible/roles/_common/defaults/main.yml
@@ -51,7 +51,7 @@ _common_ansible_pull_enabled: yes
 
 _common_ansible_pull_repo_url: https://github.com/CODA-19/deploy-scripts.git
 _common_ansible_pull_repo_branch: 
-  - orange: addes6-gitbranch-selection
+  - orange: master
   - green: master
 
 _common_ansible_pull_directory: /opt/coda19/deploy-scripts-pull

--- a/ansible/roles/_common/defaults/main.yml
+++ b/ansible/roles/_common/defaults/main.yml
@@ -51,8 +51,8 @@ _common_ansible_pull_enabled: yes
 
 _common_ansible_pull_repo_url: https://github.com/CODA-19/deploy-scripts.git
 _common_ansible_pull_repo_branch: 
-  - orange: master
-  - green: master
+  orange: master
+  green: master
 
 _common_ansible_pull_directory: /opt/coda19/deploy-scripts-pull
 _common_ansible_pull_log_dir: /var/log/ansible

--- a/ansible/roles/_common/defaults/main.yml
+++ b/ansible/roles/_common/defaults/main.yml
@@ -169,3 +169,4 @@ _common_system_upgrade_tag: ""
 # Does nothing if empty string
 
 _common_reboot_tag: ""
+

--- a/ansible/roles/_common/defaults/main.yml
+++ b/ansible/roles/_common/defaults/main.yml
@@ -50,7 +50,10 @@ _common_heartbeat_interval: 5
 _common_ansible_pull_enabled: yes
 
 _common_ansible_pull_repo_url: https://github.com/CODA-19/deploy-scripts.git
-_common_ansible_pull_repo_branch: master
+_common_ansible_pull_repo_branch: 
+  - orange: master
+  - green: master
+
 _common_ansible_pull_directory: /opt/coda19/deploy-scripts-pull
 _common_ansible_pull_log_dir: /var/log/ansible
 

--- a/ansible/roles/_common/defaults/main.yml
+++ b/ansible/roles/_common/defaults/main.yml
@@ -51,7 +51,7 @@ _common_ansible_pull_enabled: yes
 
 _common_ansible_pull_repo_url: https://github.com/CODA-19/deploy-scripts.git
 _common_ansible_pull_repo_branch: 
-  - orange: master
+  - orange: addes6-gitbranch-selection
   - green: master
 
 _common_ansible_pull_directory: /opt/coda19/deploy-scripts-pull

--- a/ansible/roles/_common/templates/usr/local/bin/execute-ansible-pull.sh.j2
+++ b/ansible/roles/_common/templates/usr/local/bin/execute-ansible-pull.sh.j2
@@ -56,7 +56,7 @@ chmod go-rwx ${ANSIBLE_LOG_DIR}
   # Fire!
   ansible-pull \
     --url {{ _common_ansible_pull_repo_url }} \
-    --checkout {{ _common_ansible_pull_repo_branch }} \
+    --checkout {{ _common_ansible_pull_repo_branch[coda19_host_role] | default("master") }} \
     --vault-password-file /etc/ansible/vault.pass \
     --directory ${PULL_BASE} \
     --inventory ${ANSIBLE_BASE}/hosts.localhost \


### PR DESCRIPTION
This PR is makes possible to change the Git branches/tags/commit used by the orange and green machines separately. This is really useful in the case you want, for example, switch a green machine of a CODA site on some development branch while leaving the  orange machine the rolling-release production branch or if you want to stick machines on a special tag or commit.

The branch "master" is used by default if, for some reason,  the branch to be used would have not been specified in the variables (at the role level, "master" is used however).

