### PR TITLE
ansible-requirements.txt path fixed to use a relative path defined in all circumstances

### DIFF
--- a/ansible/roles/_common/tasks/ansible.yml
+++ b/ansible/roles/_common/tasks/ansible.yml
@@ -14,7 +14,7 @@
 
 - name: "VENV | COPY | requirements.txt -> /opt/coda19/ansible-requirements.txt"
   copy:
-    src: "{{ inventory_dir }}/requirements.txt"
+    src: "{{ playbook_dir }}/../requirements.txt"
     dest: /opt/coda19/ansible-requirements.txt
 
 - name: "VENV | STAT | /opt/coda19/ansible-requirements.txt"


### PR DESCRIPTION
Running the playbook while deploying a sandbox makes no use of inventory files hence inventory_dir is set to 'None' :(
